### PR TITLE
Refactor share controls into reusable module

### DIFF
--- a/countdown.html
+++ b/countdown.html
@@ -395,43 +395,6 @@ function parseDateTimeIT(dateStr, timeStr){
 
 /* ====== INIT ====== */
 (async function init(){
-  // Pulsanti social
-  document.getElementById('igFab').addEventListener('click', ()=>{
-    const username='asd_petriolese_calcio';
-    const web='https://www.instagram.com/asd_petriolese_calcio/';
-    const scheme=`instagram://user?username=${username}`;
-    const isMobile=/Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
-    if(isMobile){ const start=Date.now(); location.href=scheme; setTimeout(()=>{ if(Date.now()-start<1600) window.open(web,'_blank','noopener'); },700); }
-    else{ window.open(web,'_blank','noopener'); }
-  }, {passive:true});
-
-  document.getElementById('waFab').addEventListener('click', ()=>{
-    const url='https://whatsapp.com/channel/0029Vb6QY82I7BeLPf1qXZ2E';
-    window.open(url, '_blank', 'noopener');
-  }, {passive:true});
-
-  const shareBtn=document.getElementById('shareFab');
-  shareBtn.addEventListener('click', async()=>{
-    try{
-      shareBtn.setAttribute('aria-busy','true');
-      const stage=document.querySelector('.stage'); const prev = shareBtn.style.visibility; shareBtn.style.visibility='hidden';
-      const scale=Math.max(3, window.devicePixelRatio||1);
-      const canvas=await html2canvas(stage,{backgroundColor:'#0b0c11',scale});
-      shareBtn.style.visibility=prev||'visible';
-      const out=document.createElement('canvas'); out.width=1080; out.height=1920;
-      const ctx=out.getContext('2d'); ctx.fillStyle='#0b0c11'; ctx.fillRect(0,0,out.width,out.height);
-      const ratio=Math.min(out.width/canvas.width, out.height/canvas.height);
-      const w=Math.round(canvas.width*ratio), h=Math.round(canvas.height*ratio);
-      const x=Math.floor((out.width-w)/2), y=Math.floor((out.height-h)/2);
-      ctx.drawImage(canvas,x,y,w,h);
-      const blob=await new Promise(r=>out.toBlob(r,'image/png',0.95));
-      const file=new File([blob], `countdown_petriolese_${new Date().toISOString().slice(0,10)}.png`, {type:'image/png'});
-      if(navigator.canShare && navigator.canShare({files:[file]})){ await navigator.share({title:'Countdown – Petriolese', files:[file]}); }
-      else{ const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download=file.name; document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url); }
-    }catch(e){ console.error(e); alert('Condivisione non disponibile.'); }
-    finally{ shareBtn.removeAttribute('aria-busy'); }
-  });
-
   // Dati dallo Sheet
   const [metaRows, oppRows] = await Promise.all([
     fetchCsvPrefer(SHEET_FILE_ID, META_GID, PUBLISHED_META_URL),
@@ -658,6 +621,54 @@ if (competizione){
   </div>
 </div>
 </div>
+
+<script type="module">
+import { createStageShareHandler, createInstagramOpener, createWhatsAppOpener } from './js/share-controls.js';
+
+function setupCountdownShare(){
+  const stage = document.querySelector('.stage');
+  const shareFab = document.getElementById('shareFab');
+  const igFab = document.getElementById('igFab');
+  const waFab = document.getElementById('waFab');
+
+  if(igFab){
+    const openInstagram = createInstagramOpener({ username: 'asd_petriolese_calcio' });
+    igFab.addEventListener('click', openInstagram, { passive: true });
+  }
+
+  if(waFab){
+    const openWhatsApp = createWhatsAppOpener({ url: 'https://whatsapp.com/channel/0029Vb6QY82I7BeLPf1qXZ2E' });
+    waFab.addEventListener('click', openWhatsApp, { passive: true });
+  }
+
+  if(!stage || !shareFab) return;
+
+  const shareHandler = createStageShareHandler(stage, {
+    hideDuringCapture: [shareFab, igFab, waFab],
+    shareTitle: 'Countdown – Petriolese',
+    fileNamePrefix: 'countdown_petriolese',
+    backgroundColor: '#0b0c11'
+  });
+
+  shareFab.addEventListener('click', async () => {
+    try{
+      shareFab.setAttribute('aria-busy', 'true');
+      await shareHandler();
+    }catch(error){
+      console.error(error);
+      alert('Condivisione non disponibile.');
+    }finally{
+      shareFab.removeAttribute('aria-busy');
+    }
+  }, { passive: true });
+}
+
+if(document.readyState === 'loading'){
+  document.addEventListener('DOMContentLoaded', setupCountdownShare, { once: true });
+}else{
+  setupCountdownShare();
+}
+</script>
 
 </body>
 </html>

--- a/fulltime.html
+++ b/fulltime.html
@@ -281,40 +281,6 @@ function readScore(meta){
 
 /* ====== INIT ====== */
 (async function init(){
-  // socials
-  document.getElementById('igFab').addEventListener('click', ()=>{
-    const username='asd_petriolese_calcio';
-    const web='https://www.instagram.com/asd_petriolese_calcio/';
-    const scheme=`instagram://user?username=${username}`;
-    const isMobile=/Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
-    if(isMobile){ const start=Date.now(); location.href=scheme; setTimeout(()=>{ if(Date.now()-start<1600) window.open(web,'_blank','noopener'); },700); }
-    else{ window.open(web,'_blank','noopener'); }
-  }, {passive:true});
-  document.getElementById('waFab').addEventListener('click', ()=>{ window.open('https://whatsapp.com/channel/0029Vb6QY82I7BeLPf1qXZ2E','_blank','noopener'); }, {passive:true});
-
-  // share
-  const shareBtn=document.getElementById('shareFab');
-  shareBtn.addEventListener('click', async()=>{
-    try{
-      shareBtn.setAttribute('aria-busy','true');
-      const stage=document.querySelector('.stage'); const prev=shareBtn.style.visibility; shareBtn.style.visibility='hidden';
-      const scale=Math.max(3, window.devicePixelRatio||1);
-      const canvas=await html2canvas(stage,{backgroundColor:'#0b0c11',scale});
-      shareBtn.style.visibility=prev||'visible';
-      const out=document.createElement('canvas'); out.width=1080; out.height=1920;
-      const ctx=out.getContext('2d'); ctx.fillStyle='#0b0c11'; ctx.fillRect(0,0,out.width,out.height);
-      const ratio=Math.min(out.width/canvas.width, out.height/canvas.height);
-      const w=Math.round(canvas.width*ratio), h=Math.round(canvas.height*ratio);
-      const x=Math.floor((out.width-w)/2), y=Math.floor((out.height-h)/2);
-      ctx.drawImage(canvas,x,y,w,h);
-      const blob=await new Promise(r=>out.toBlob(r,'image/png',0.95));
-      const file=new File([blob], `fulltime_petriolese_${new Date().toISOString().slice(0,10)}.png`, {type:'image/png'});
-      if(navigator.canShare && navigator.canShare({files:[file]})){ await navigator.share({title:'Full Time – Petriolese', files:[file]}); }
-      else{ const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download=file.name; document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url); }
-    }catch(e){ console.error(e); alert('Condivisione non disponibile.'); }
-    finally{ shareBtn.removeAttribute('aria-busy'); }
-  });
-
   // sheet
   const [metaRows, oppRows] = await Promise.all([
     fetchCsvPrefer(SHEET_FILE_ID, META_GID, PUBLISHED_META_URL),
@@ -385,5 +351,53 @@ function readScore(meta){
 
 <!-- html2canvas -->
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js" defer></script>
+
+<script type="module">
+import { createStageShareHandler, createInstagramOpener, createWhatsAppOpener } from './js/share-controls.js';
+
+function setupFullTimeShare(){
+  const stage = document.querySelector('.stage');
+  const shareFab = document.getElementById('shareFab');
+  const igFab = document.getElementById('igFab');
+  const waFab = document.getElementById('waFab');
+
+  if(igFab){
+    const openInstagram = createInstagramOpener({ username: 'asd_petriolese_calcio' });
+    igFab.addEventListener('click', openInstagram, { passive: true });
+  }
+
+  if(waFab){
+    const openWhatsApp = createWhatsAppOpener({ url: 'https://whatsapp.com/channel/0029Vb6QY82I7BeLPf1qXZ2E' });
+    waFab.addEventListener('click', openWhatsApp, { passive: true });
+  }
+
+  if(!stage || !shareFab) return;
+
+  const shareHandler = createStageShareHandler(stage, {
+    hideDuringCapture: [shareFab, igFab, waFab],
+    shareTitle: 'Full Time – Petriolese',
+    fileNamePrefix: 'fulltime_petriolese',
+    backgroundColor: '#0b0c11'
+  });
+
+  shareFab.addEventListener('click', async () => {
+    try{
+      shareFab.setAttribute('aria-busy', 'true');
+      await shareHandler();
+    }catch(error){
+      console.error(error);
+      alert('Condivisione non disponibile.');
+    }finally{
+      shareFab.removeAttribute('aria-busy');
+    }
+  }, { passive: true });
+}
+
+if(document.readyState === 'loading'){
+  document.addEventListener('DOMContentLoaded', setupFullTimeShare, { once: true });
+}else{
+  setupFullTimeShare();
+}
+</script>
 </body>
 </html>

--- a/js/share-controls.js
+++ b/js/share-controls.js
@@ -1,0 +1,261 @@
+const TARGET_WIDTH = 1080;
+const TARGET_HEIGHT = 1920;
+const DEFAULT_BACKGROUND = '#0b0c11';
+const MOBILE_REGEX = /Android|iPhone|iPad|iPod/i;
+
+function createMobileDetector(override){
+  if(typeof override === 'function'){
+    return () => {
+      try{
+        return Boolean(override());
+      }catch{
+        return false;
+      }
+    };
+  }
+  return () => {
+    try{
+      return MOBILE_REGEX.test(navigator.userAgent || '');
+    }catch{
+      return false;
+    }
+  };
+}
+
+function isElement(value){
+  return value instanceof Element;
+}
+
+function asElementArray(value){
+  if(!value) return [];
+  if(Array.isArray(value)) return value.filter(isElement);
+  return isElement(value) ? [value] : [];
+}
+
+function hideTemporarily(elements){
+  const stored = [];
+  elements.forEach(el => {
+    stored.push([el, el.style.visibility]);
+    el.style.visibility = 'hidden';
+  });
+  return () => {
+    stored.forEach(([el, previous]) => {
+      if(previous){
+        el.style.visibility = previous;
+      }else{
+        el.style.removeProperty('visibility');
+      }
+    });
+  };
+}
+
+function canvasToBlob(canvas, type, quality){
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(blob => {
+      if(blob){
+        resolve(blob);
+      }else{
+        reject(new Error('Impossibile generare l\'immagine.'));
+      }
+    }, type, quality);
+  });
+}
+
+function downloadBlob(blob, fileName){
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function defaultFileNameFormatter(prefix){
+  const base = prefix || 'share';
+  const today = new Date().toISOString().slice(0, 10);
+  return `${base}_${today}.png`;
+}
+
+function resolveFileName(options){
+  if(options.fileName) return options.fileName;
+  const formatter = typeof options.fileNameFormatter === 'function' ? options.fileNameFormatter : defaultFileNameFormatter;
+  return formatter(options.fileNamePrefix || 'share', options);
+}
+
+function ensureContext(canvas){
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  if(!ctx){
+    throw new Error('Impossibile ottenere il contesto 2D.');
+  }
+  return ctx;
+}
+
+export function createStageShareHandler(stage, baseOptions = {}){
+  if(!isElement(stage)){
+    throw new Error('createStageShareHandler richiede un elemento stage valido.');
+  }
+
+  const defaults = {
+    targetWidth: TARGET_WIDTH,
+    targetHeight: TARGET_HEIGHT,
+    backgroundColor: DEFAULT_BACKGROUND,
+    fileNamePrefix: 'share',
+    hideDuringCapture: [],
+    captureClass: null,
+    blobType: 'image/png',
+    blobQuality: 0.95,
+    shareTitle: '',
+    shareText: '',
+    minScale: 3,
+    useCORS: true,
+    html2canvasOptions: null,
+    fileNameFormatter: defaultFileNameFormatter,
+    onAfterShare: null,
+    onBeforeCapture: null
+  };
+
+  return async function share(customOptions = {}){
+    const options = { ...defaults, ...baseOptions, ...customOptions };
+    const hideList = asElementArray(options.hideDuringCapture);
+    const restoreVisibility = hideTemporarily(hideList);
+
+    if(typeof options.onBeforeCapture === 'function'){
+      try{ options.onBeforeCapture(options); }catch{ /* ignore */ }
+    }
+
+    if(options.captureClass){
+      stage.classList.add(options.captureClass);
+    }
+
+    try{
+      const rect = stage.getBoundingClientRect();
+      const targetWidth = options.targetWidth;
+      const targetHeight = options.targetHeight;
+      const width = rect.width || targetWidth;
+      const height = rect.height || targetHeight;
+      const dpr = Math.max(1, window.devicePixelRatio || 1);
+      const needScale = Math.max(targetWidth / width, targetHeight / height);
+      const scale = Math.max(options.minScale, dpr, needScale);
+
+      const extraOptions = options.html2canvasOptions && typeof options.html2canvasOptions === 'object'
+        ? { ...options.html2canvasOptions }
+        : {};
+
+      if(extraOptions.scale == null){
+        extraOptions.scale = scale;
+      }
+      if(extraOptions.backgroundColor == null){
+        extraOptions.backgroundColor = options.backgroundColor;
+      }
+      if(extraOptions.useCORS == null){
+        extraOptions.useCORS = options.useCORS !== false;
+      }
+
+      const canvas = await html2canvas(stage, extraOptions);
+
+      const out = document.createElement('canvas');
+      out.width = targetWidth;
+      out.height = targetHeight;
+      const ctx = ensureContext(out);
+      ctx.fillStyle = options.backgroundColor;
+      ctx.fillRect(0, 0, targetWidth, targetHeight);
+      ctx.imageSmoothingEnabled = true;
+      ctx.imageSmoothingQuality = 'high';
+
+      const ratio = Math.min(targetWidth / canvas.width, targetHeight / canvas.height);
+      const w = Math.round(canvas.width * ratio);
+      const h = Math.round(canvas.height * ratio);
+      const x = Math.floor((targetWidth - w) / 2);
+      const y = Math.floor((targetHeight - h) / 2);
+      ctx.drawImage(canvas, x, y, w, h);
+
+      const blob = await canvasToBlob(out, options.blobType, options.blobQuality);
+      const fileName = resolveFileName(options);
+      const file = typeof File === 'function' ? new File([blob], fileName, { type: options.blobType }) : null;
+      const nav = typeof navigator !== 'undefined' ? navigator : null;
+      const canShareFiles = !!(file && nav && typeof nav.canShare === 'function' && nav.canShare({ files: [file] }));
+
+      if(canShareFiles && nav && typeof nav.share === 'function'){
+        await nav.share({
+          title: options.shareTitle,
+          text: options.shareText,
+          files: [file]
+        });
+        if(typeof options.onAfterShare === 'function'){
+          options.onAfterShare({ shared: true, blob, file, fileName, options });
+        }
+        return { shared: true, blob, file, fileName };
+      }
+
+      downloadBlob(blob, fileName);
+      if(typeof options.onAfterShare === 'function'){
+        options.onAfterShare({ shared: false, blob, file, fileName, options });
+      }
+      return { shared: false, blob, file, fileName };
+    }finally{
+      if(options.captureClass){
+        stage.classList.remove(options.captureClass);
+      }
+      restoreVisibility();
+    }
+  };
+}
+
+export function createInstagramOpener(options = {}){
+  const {
+    username = '',
+    webUrl,
+    appUrl,
+    mobileDetector,
+    fallbackDelay = 700,
+    fallbackWindow = 1600
+  } = options;
+
+  const finalWebUrl = webUrl || (username ? `https://www.instagram.com/${username}/` : 'https://www.instagram.com/');
+  const finalAppUrl = appUrl || (username ? `instagram://user?username=${username}` : 'instagram://app');
+  const isMobile = createMobileDetector(mobileDetector);
+
+  return () => {
+    if(isMobile()){
+      const start = Date.now();
+      window.location.href = finalAppUrl;
+      window.setTimeout(() => {
+        if(Date.now() - start < fallbackWindow){
+          window.open(finalWebUrl, '_blank', 'noopener');
+        }
+      }, fallbackDelay);
+    }else{
+      window.open(finalWebUrl, '_blank', 'noopener');
+    }
+  };
+}
+
+export function createWhatsAppOpener(options = {}){
+  const {
+    url,
+    desktopUrl,
+    mobileDetector,
+    mobileTarget = '_blank',
+    desktopTarget = '_blank'
+  } = options;
+
+  const targetUrl = url || 'https://www.whatsapp.com/';
+  const desktopFallback = desktopUrl || targetUrl;
+  const isMobile = createMobileDetector(mobileDetector);
+
+  return () => {
+    const isOnMobile = isMobile();
+    const finalTarget = isOnMobile ? mobileTarget : desktopTarget;
+    const finalUrl = isOnMobile ? targetUrl : desktopFallback;
+
+    if(finalTarget === '_self'){
+      window.location.href = finalUrl;
+    }else{
+      window.open(finalUrl, finalTarget, 'noopener');
+    }
+  };
+}
+
+export { TARGET_WIDTH, TARGET_HEIGHT };

--- a/lineup.html
+++ b/lineup.html
@@ -719,104 +719,54 @@ function render(byNum, modulo="3412"){
 </script>
 
 <!-- Share / Download -->
-<script>
-document.addEventListener('DOMContentLoaded', ()=>{
-  const fab = document.getElementById('shareFab');
-  const ig  = document.getElementById('igFab');
-  const wa  = document.getElementById('waFab');
+<script type="module">
+import { createStageShareHandler, createInstagramOpener, createWhatsAppOpener } from './js/share-controls.js';
+
+function setupShareControls(){
   const stage = document.querySelector('.stage');
+  const shareFab = document.getElementById('shareFab');
+  const igFab = document.getElementById('igFab');
+  const waFab = document.getElementById('waFab');
 
-  async function stageToBlob(){
-    const prevVis = fab.style.visibility;
-    const prevVisIG = ig ? ig.style.visibility : '';
-    const prevVisWA = wa ? wa.style.visibility : '';
-
-    fab.style.visibility = 'hidden';
-    if(ig) ig.style.visibility = 'hidden';
-    if(wa) wa.style.visibility = 'hidden';
-    stage.classList.add('is-capturing');
-
-    const targetW = 1080, targetH = 1920;
-    const rect = stage.getBoundingClientRect();
-    const dpr  = Math.max(1, window.devicePixelRatio || 1);
-    const need = Math.max(targetW / rect.width, targetH / rect.height);
-    const scale = Math.max(3, dpr, need);
-
-    const canvas = await html2canvas(stage, {
-      backgroundColor: '#0b0c11',
-      scale,
-      useCORS: true
-    });
-
-    const out = document.createElement('canvas');
-    out.width = targetW; out.height = targetH;
-    const ctx = out.getContext('2d', { willReadFrequently:true });
-
-    ctx.fillStyle = '#0b0c11';
-    ctx.fillRect(0,0,targetW,targetH);
-    ctx.imageSmoothingEnabled = true;
-    ctx.imageSmoothingQuality = 'high';
-
-    const ratio = Math.min(targetW/canvas.width, targetH/canvas.height);
-    const w = Math.round(canvas.width * ratio);
-    const h = Math.round(canvas.height * ratio);
-    const x = Math.floor((targetW - w)/2);
-    const y = Math.floor((targetH - h)/2);
-    ctx.drawImage(canvas, x, y, w, h);
-
-    stage.classList.remove('is-capturing');
-    fab.style.visibility = prevVis || 'visible';
-    if(ig) ig.style.visibility = prevVisIG || 'visible';
-    if(wa) wa.style.visibility = prevVisWA || 'visible';
-
-    return await new Promise(res=> out.toBlob(b=>res(b), 'image/png', 0.95));
+  if(igFab){
+    const openInstagram = createInstagramOpener({ username: 'asd_petriolese_calcio' });
+    igFab.addEventListener('click', openInstagram, { passive: true });
   }
 
-  async function shareOrDownload(){
-    try{
-      fab.setAttribute('aria-busy','true');
-      const blob = await stageToBlob();
-      const fileName = `matchday_petriolese_${new Date().toISOString().slice(0,10)}.png`;
+  if(waFab){
+    const openWhatsApp = createWhatsAppOpener({ url: 'https://whatsapp.com/channel/0029Vb6QY82I7BeLPf1qXZ2E' });
+    waFab.addEventListener('click', openWhatsApp, { passive: true });
+  }
 
-      const file = new File([blob], fileName, { type: 'image/png' });
-      if(navigator.canShare && navigator.canShare({ files: [file] })){
-        await navigator.share({ title:'Matchday – Petriolese Calcio', text:'Formazione titolari e panchina.', files:[file] });
-        fab.removeAttribute('aria-busy'); return;
-      }
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a'); a.href = url; a.download = fileName;
-      document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url);
-      fab.removeAttribute('aria-busy');
+  if(!stage || !shareFab) return;
+
+  const shareHandler = createStageShareHandler(stage, {
+    hideDuringCapture: [shareFab, igFab, waFab],
+    captureClass: 'is-capturing',
+    shareTitle: 'Matchday – Petriolese Calcio',
+    shareText: 'Formazione titolari e panchina.',
+    fileNamePrefix: 'matchday_petriolese',
+    backgroundColor: '#0b0c11'
+  });
+
+  shareFab.addEventListener('click', async () => {
+    try{
+      shareFab.setAttribute('aria-busy', 'true');
+      await shareHandler();
     }catch(err){
       console.error(err);
-      fab.removeAttribute('aria-busy');
       alert('Impossibile condividere automaticamente.');
+    }finally{
+      shareFab.removeAttribute('aria-busy');
     }
-  }
+  }, { passive: true });
+}
 
-  function openInstagram(){
-    const web = 'https://www.instagram.com/asd_petriolese_calcio/';
-    const scheme = 'instagram://user?username=asd_petriolese_calcio';
-    const isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
-
-    if(isMobile){
-      const start = Date.now();
-      window.location.href = scheme;
-      setTimeout(()=>{ if(Date.now() - start < 1600){ window.open(web, '_blank', 'noopener'); } }, 700);
-    }else{
-      window.open(web, '_blank', 'noopener');
-    }
-  }
-
-  const WHATSAPP_CHANNEL_URL = 'https://whatsapp.com/channel/0029Vb6QY82I7BeLPf1qXZ2E';
-  function openWhatsAppChannel(){
-    window.open(WHATSAPP_CHANNEL_URL, '_blank', 'noopener');
-  }
-
-  fab.addEventListener('click', shareOrDownload, { passive:true });
-  ig.addEventListener('click', openInstagram, { passive:true });
-  wa.addEventListener('click', openWhatsAppChannel, { passive:true });
-});
+if(document.readyState === 'loading'){
+  document.addEventListener('DOMContentLoaded', setupShareControls, { once: true });
+}else{
+  setupShareControls();
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a reusable `js/share-controls.js` helper to capture the stage, share via Web Share or download, and open Instagram/WhatsApp links
- update `lineup.html`, `countdown.html`, and `fulltime.html` to consume the shared helpers with page-specific share metadata
- keep the share button busy state handling while centralising the social FAB logic across the three pages

## Testing
- python3 -m http.server 8000 & browser_container Playwright smoke test for lineup/countdown/fulltime (existing countdown timer script raises `Cannot access 't' before initialization` when the match is already live)


------
https://chatgpt.com/codex/tasks/task_e_68d03061c50483258d297f231239a6f3