### PR TITLE
Stack full-time scorers vertically

### DIFF
--- a/fulltime.html
+++ b/fulltime.html
@@ -54,13 +54,14 @@
     box-shadow:0 0 0 1px rgba(255,255,255,.06) inset;
     color:#e6ebf2; font-weight:600; font-size:clamp(12px,2.1cqw,16px);
     line-height:1.5; padding:.8cqh 1.1cqw;
-    display:flex; flex-wrap:wrap; gap:.6cqw .9cqw; min-height:3.2cqh;
+    display:grid; grid-auto-rows:min-content; gap:.6cqh; min-height:3.2cqh;
+    justify-items:start; text-align:left;
     max-width:min(44cqw, 520px);
   }
   #wingTop { justify-items:start; }
   #wingTop .wing { justify-self:start; }   /* a sinistra */
   #wingBottom { justify-items:end; }
-  #wingBottom .wing { justify-self:end; }  /* a destra  */
+  #wingBottom .wing { justify-self:end; justify-items:end; text-align:right; }  /* a destra  */
   .scorer{ display:inline-flex; align-items:center; gap:.35cqw; white-space:nowrap; }
   .scorer .ball{ transform:translateY(.02em); }
 


### PR DESCRIPTION
## Summary
- switch the full-time scorer containers to a vertical grid layout so each marker stacks in a column
- keep alignment cues by anchoring the top wing to the left and the bottom wing to the right

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d902fd81388325a384954cfe232dba