### PR TITLE
Ensure background video is hidden during share capture

### DIFF
--- a/fulltime.html
+++ b/fulltime.html
@@ -373,16 +373,18 @@ function setupFullTimeShare(){
 
   if(!stage || !shareFab) return;
 
-  const shareHandler = createStageShareHandler(stage, {
-    hideDuringCapture: [shareFab, igFab, waFab, bgVideo],
+  const shareOptions = {
+    hideDuringCapture: [shareFab, igFab, waFab, bgVideo].filter(Boolean),
     captureClass: 'is-capturing',
-    shareTitle: 'Full Time – Petriolese',
-    fileNamePrefix: 'fulltime_petriolese',
+    shareTitle: stage.dataset.shareTitle || 'Full Time – Petriolese Calcio',
+    fileNamePrefix: stage.dataset.sharePrefix || 'fulltime_petriolese_calcio',
     backgroundColor: '#0b0c11',
     targetWidth: 1080,
     targetHeight: 1080,
     fitMode: 'cover'
-  });
+  };
+
+  const shareHandler = createStageShareHandler(stage, shareOptions);
 
   shareFab.addEventListener('click', async () => {
     try{

--- a/fulltime.html
+++ b/fulltime.html
@@ -26,6 +26,7 @@
   /* video bg */
   #bg-video{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; z-index:0;
              filter:brightness(.32) contrast(1.05) saturate(1.05); background:#0b0c11; }
+  .stage.is-capturing #bg-video{ display:none !important; }
 
   /* overlay */
   .stadium{ position:absolute; inset:0; z-index:1; pointer-events:none;
@@ -54,13 +55,14 @@
     box-shadow:0 0 0 1px rgba(255,255,255,.06) inset;
     color:#e6ebf2; font-weight:600; font-size:clamp(12px,2.1cqw,16px);
     line-height:1.5; padding:.8cqh 1.1cqw;
-    display:flex; flex-wrap:wrap; gap:.6cqw .9cqw; min-height:3.2cqh;
+    display:grid; grid-auto-rows:min-content; gap:.6cqh; min-height:3.2cqh;
+    justify-items:start; text-align:left;
     max-width:min(44cqw, 520px);
   }
   #wingTop { justify-items:start; }
   #wingTop .wing { justify-self:start; }   /* a sinistra */
   #wingBottom { justify-items:end; }
-  #wingBottom .wing { justify-self:end; }  /* a destra  */
+  #wingBottom .wing { justify-self:end; justify-items:end; text-align:right; }  /* a destra  */
   .scorer{ display:inline-flex; align-items:center; gap:.35cqw; white-space:nowrap; }
   .scorer .ball{ transform:translateY(.02em); }
 
@@ -357,6 +359,7 @@ function setupFullTimeShare(){
   const shareFab = document.getElementById('shareFab');
   const igFab = document.getElementById('igFab');
   const waFab = document.getElementById('waFab');
+  const bgVideo = document.getElementById('bg-video');
 
   if(igFab){
     const openInstagram = createInstagramOpener({ username: 'asd_petriolese_calcio' });
@@ -371,10 +374,14 @@ function setupFullTimeShare(){
   if(!stage || !shareFab) return;
 
   const shareHandler = createStageShareHandler(stage, {
-    hideDuringCapture: [shareFab, igFab, waFab],
+    hideDuringCapture: [shareFab, igFab, waFab, bgVideo],
+    captureClass: 'is-capturing',
     shareTitle: 'Full Time – Petriolese',
     fileNamePrefix: 'fulltime_petriolese',
-    backgroundColor: '#0b0c11'
+    backgroundColor: '#0b0c11',
+    targetWidth: 1080,
+    targetHeight: 1080,
+    fitMode: 'cover'
   });
 
   shareFab.addEventListener('click', async () => {

--- a/fulltime.html
+++ b/fulltime.html
@@ -352,7 +352,7 @@ function readScore(meta){
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js" defer></script>
 
 <script type="module">
-import { createStageShareHandler, createInstagramOpener, createWhatsAppOpener, createFullTimeShareOptions } from './js/share-controls.js';
+import { createStageShareHandler, createInstagramOpener, createWhatsAppOpener } from './js/share-controls.js';
 
 function setupFullTimeShare(){
   const stage = document.querySelector('.stage');
@@ -373,8 +373,17 @@ function setupFullTimeShare(){
 
   if(!stage || !shareFab) return;
 
-  const shareOptions = createFullTimeShareOptions({ stage, shareFab, igFab, waFab, bgVideo });
-  const shareHandler = createStageShareHandler(stage, shareOptions);
+  const hideDuringCapture = [shareFab, igFab, waFab, bgVideo].filter(Boolean);
+  const shareHandler = createStageShareHandler(stage, {
+    hideDuringCapture,
+    captureClass: 'is-capturing',
+    shareTitle: stage.dataset.shareTitle || 'Full Time – Petriolese Calcio',
+    fileNamePrefix: stage.dataset.sharePrefix || 'fulltime_petriolese_calcio',
+    backgroundColor: '#0b0c11',
+    targetWidth: 1080,
+    targetHeight: 1080,
+    fitMode: 'cover'
+  });
 
   shareFab.addEventListener('click', async () => {
     try{

--- a/fulltime.html
+++ b/fulltime.html
@@ -352,7 +352,7 @@ function readScore(meta){
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js" defer></script>
 
 <script type="module">
-import { createStageShareHandler, createInstagramOpener, createWhatsAppOpener } from './js/share-controls.js';
+import { createStageShareHandler, createInstagramOpener, createWhatsAppOpener, createFullTimeShareOptions } from './js/share-controls.js';
 
 function setupFullTimeShare(){
   const stage = document.querySelector('.stage');
@@ -373,17 +373,7 @@ function setupFullTimeShare(){
 
   if(!stage || !shareFab) return;
 
-  const shareOptions = {
-    hideDuringCapture: [shareFab, igFab, waFab, bgVideo].filter(Boolean),
-    captureClass: 'is-capturing',
-    shareTitle: stage.dataset.shareTitle || 'Full Time – Petriolese Calcio',
-    fileNamePrefix: stage.dataset.sharePrefix || 'fulltime_petriolese_calcio',
-    backgroundColor: '#0b0c11',
-    targetWidth: 1080,
-    targetHeight: 1080,
-    fitMode: 'cover'
-  };
-
+  const shareOptions = createFullTimeShareOptions({ stage, shareFab, igFab, waFab, bgVideo });
   const shareHandler = createStageShareHandler(stage, shareOptions);
 
   shareFab.addEventListener('click', async () => {

--- a/js/share-controls.js
+++ b/js/share-controls.js
@@ -111,6 +111,7 @@ export function createStageShareHandler(stage, baseOptions = {}){
     minScale: 1,
     useCORS: true,
     html2canvasOptions: null,
+    fitMode: 'contain',
     fileNameFormatter: defaultFileNameFormatter,
     onAfterShare: null,
     onBeforeCapture: null
@@ -170,9 +171,16 @@ export function createStageShareHandler(stage, baseOptions = {}){
       ctx.imageSmoothingEnabled = true;
       ctx.imageSmoothingQuality = 'high';
 
-      const ratio = Math.min(targetWidth / canvas.width, targetHeight / canvas.height);
-      const w = Math.round(canvas.width * ratio);
-      const h = Math.round(canvas.height * ratio);
+      const sourceWidth = canvas.width || 1;
+      const sourceHeight = canvas.height || 1;
+      const fitMode = options.fitMode === 'cover' ? 'cover' : 'contain';
+      const ratioFn = fitMode === 'cover' ? Math.max : Math.min;
+      let ratio = ratioFn(targetWidth / sourceWidth, targetHeight / sourceHeight);
+      if(!Number.isFinite(ratio) || ratio <= 0){
+        ratio = 1;
+      }
+      const w = Math.round(sourceWidth * ratio);
+      const h = Math.round(sourceHeight * ratio);
       const x = Math.floor((targetWidth - w) / 2);
       const y = Math.floor((targetHeight - h) / 2);
       ctx.drawImage(canvas, x, y, w, h);

--- a/js/share-controls.js
+++ b/js/share-controls.js
@@ -1,15 +1,6 @@
 const TARGET_WIDTH = 1080;
 const TARGET_HEIGHT = 1920;
 const DEFAULT_BACKGROUND = '#0b0c11';
-const FULLTIME_DEFAULTS = {
-  captureClass: 'is-capturing',
-  shareTitle: 'Full Time – Petriolese Calcio',
-  fileNamePrefix: 'fulltime_petriolese_calcio',
-  backgroundColor: DEFAULT_BACKGROUND,
-  targetWidth: 1080,
-  targetHeight: 1080,
-  fitMode: 'cover'
-};
 const MOBILE_REGEX = /Android|iPhone|iPad|iPod/i;
 
 function createMobileDetector(override){
@@ -39,40 +30,6 @@ function asElementArray(value){
   if(!value) return [];
   if(Array.isArray(value)) return value.filter(isElement);
   return isElement(value) ? [value] : [];
-}
-
-function mergeCaptureList(base, extra){
-  const list = [];
-  if(Array.isArray(base)){
-    base.forEach(item => {
-      if(isElement(item)) list.push(item);
-    });
-  }else if(isElement(base)){
-    list.push(base);
-  }
-  if(Array.isArray(extra)){
-    extra.forEach(item => {
-      if(isElement(item)) list.push(item);
-    });
-  }else if(isElement(extra)){
-    list.push(extra);
-  }
-  return list;
-}
-
-export function createFullTimeShareOptions(context = {}, overrides = {}){
-  const { stage = null, shareFab = null, igFab = null, waFab = null, bgVideo = null, hideDuringCapture } = context;
-  const dataset = stage && stage.dataset ? stage.dataset : {};
-  const hideList = mergeCaptureList([shareFab, igFab, waFab, bgVideo], hideDuringCapture);
-
-  const base = {
-    ...FULLTIME_DEFAULTS,
-    shareTitle: dataset.shareTitle || FULLTIME_DEFAULTS.shareTitle,
-    fileNamePrefix: dataset.sharePrefix || FULLTIME_DEFAULTS.fileNamePrefix,
-    hideDuringCapture: hideList
-  };
-
-  return { ...base, ...overrides };
 }
 
 function hideTemporarily(elements){

--- a/js/share-controls.js
+++ b/js/share-controls.js
@@ -1,6 +1,15 @@
 const TARGET_WIDTH = 1080;
 const TARGET_HEIGHT = 1920;
 const DEFAULT_BACKGROUND = '#0b0c11';
+const FULLTIME_DEFAULTS = {
+  captureClass: 'is-capturing',
+  shareTitle: 'Full Time – Petriolese Calcio',
+  fileNamePrefix: 'fulltime_petriolese_calcio',
+  backgroundColor: DEFAULT_BACKGROUND,
+  targetWidth: 1080,
+  targetHeight: 1080,
+  fitMode: 'cover'
+};
 const MOBILE_REGEX = /Android|iPhone|iPad|iPod/i;
 
 function createMobileDetector(override){
@@ -30,6 +39,40 @@ function asElementArray(value){
   if(!value) return [];
   if(Array.isArray(value)) return value.filter(isElement);
   return isElement(value) ? [value] : [];
+}
+
+function mergeCaptureList(base, extra){
+  const list = [];
+  if(Array.isArray(base)){
+    base.forEach(item => {
+      if(isElement(item)) list.push(item);
+    });
+  }else if(isElement(base)){
+    list.push(base);
+  }
+  if(Array.isArray(extra)){
+    extra.forEach(item => {
+      if(isElement(item)) list.push(item);
+    });
+  }else if(isElement(extra)){
+    list.push(extra);
+  }
+  return list;
+}
+
+export function createFullTimeShareOptions(context = {}, overrides = {}){
+  const { stage = null, shareFab = null, igFab = null, waFab = null, bgVideo = null, hideDuringCapture } = context;
+  const dataset = stage && stage.dataset ? stage.dataset : {};
+  const hideList = mergeCaptureList([shareFab, igFab, waFab, bgVideo], hideDuringCapture);
+
+  const base = {
+    ...FULLTIME_DEFAULTS,
+    shareTitle: dataset.shareTitle || FULLTIME_DEFAULTS.shareTitle,
+    fileNamePrefix: dataset.sharePrefix || FULLTIME_DEFAULTS.fileNamePrefix,
+    hideDuringCapture: hideList
+  };
+
+  return { ...base, ...overrides };
 }
 
 function hideTemporarily(elements){


### PR DESCRIPTION
## Summary
- add a capture class to the full-time share handler so the stage toggles a capture state
- hide the background video in CSS whenever the stage is in capture mode so it no longer appears in exports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d902fd81388325a384954cfe232dba